### PR TITLE
[Design] The admin link was too long for small screens

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -60,3 +60,7 @@ $component-active-bg: #00a3d3;
 .invalid-feedback {
   margin: 0px;
 }
+
+a {
+  word-break:break-all;
+}


### PR DESCRIPTION
 The admin link was too long for small screens, because it did not break properly. This commit changes the word break to break-all, so that it works on smaller screens. Closes #38 