### PR TITLE
[Bug] Handling of single quote in translations #101

### DIFF
--- a/lib/qrstorage/services/gcp/google_api_service_impl.ex
+++ b/lib/qrstorage/services/gcp/google_api_service_impl.ex
@@ -24,7 +24,8 @@ defmodule Qrstorage.Services.Gcp.GoogleApiServiceImpl do
       GoogleApi.Translate.V2.Api.Translations.language_translations_list(
         authenticated_connection(),
         [text],
-        target_language
+        target_language,
+        format: "text"
       )
 
     translated_text = List.first(response.translations).translatedText


### PR DESCRIPTION
Closes #101 

The Google API defaults the format parameter to `html`, which is not useful in our case. Therefore, we need to change this to `text`. Otherwise strings like `I'm` will be returned as `I&#39;m`.