### PR TITLE
feature: introduce rate limiting for audio codes #314

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -135,6 +135,10 @@ config :qrstorage, Qrstorage.Services.Vault,
 config :qrstorage,
   translation_transition_date: System.get_env("QR_CODE_TRANSLATION_TRANSITION_DATE", "2024-07-09 00:00:00")
 
+# configure rate limiting:
+config :qrstorage,
+  rate_limiting_character_limit: String.to_integer(System.get_env("QR_CODE_RATE_LIMITING_CHARACTER_LIMIT", "25000"))
+
 # from mix phx.gen.release
 if System.get_env("PHX_SERVER") do
   config :qrstorage, QrstorageWeb.Endpoint, server: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       OBJECT_STORAGE_BUCKET: qrstorage-dev
       QR_CODE_DEFAULT_LOCALE: "de"
       QR_CODE_TRANSLATION_TRANSITION_DATE: "2024-07-09 00:00:00"
+      QR_CODE_RATE_LIMITING_CHARACTER_LIMIT: "25000"
       DEEPL_API_KEY: ""
       READSPEAKER_API_KEY: ""
       # Replace this in production with your own key!

--- a/lib/qrstorage/services/rate_limiting_service.ex
+++ b/lib/qrstorage/services/rate_limiting_service.ex
@@ -1,0 +1,32 @@
+defmodule Qrstorage.Services.RateLimitingService do
+  require Logger
+
+  alias Qrstorage.QrCodes
+  alias Qrstorage.QrCodes.QrCode
+
+  def allow?(%QrCode{} = qr_code) do
+    existing_character_count = audio_character_count_in_timeframe(qr_code)
+
+    if existing_character_count <= character_limit() do
+      true
+    else
+      Logger.warning(
+        "Rate Limit reached: QR-Code Text length: #{String.length(qr_code.text)} - Created within timeframe including QR-Code-Text-Length: #{existing_character_count} - Character Limit: #{character_limit()}."
+      )
+
+      false
+    end
+  end
+
+  defp audio_character_count_in_timeframe(qr_code) do
+    # We start with 24 - we can make this configurable later
+    hours = 24
+    past_audio_character_count = QrCodes.audio_character_count_in_last_hours(hours)
+    String.length(qr_code.text) + past_audio_character_count
+  end
+
+  defp character_limit() do
+    # load from config:
+    Application.get_env(:qrstorage, :rate_limiting_character_limit)
+  end
+end

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -228,8 +228,8 @@ msgstr "Fehler beim Upload der Audio-Datei."
 msgid "Error while extracting audio file from plug: Invalid content type"
 msgstr "Fehler beim Upload der Audio-Datei."
 
-#: lib/qrstorage/services/qr_code_service.ex:80
-#: lib/qrstorage/services/qr_code_service.ex:84
+#: lib/qrstorage/services/qr_code_service.ex:85
+#: lib/qrstorage/services/qr_code_service.ex:89
 #, elixir-autogen, elixir-format
 msgid "Qr code recording not extracted"
 msgstr "Fehler beim Upload der Audio-Datei."
@@ -260,8 +260,8 @@ msgstr "Die Seite konnte nicht gefunden werden."
 msgid "QR-Code has been deleted?"
 msgstr "QR-Codes werden nach Inaktivität und Ablauf der ausgewählten Speicherdauer gelöscht."
 
-#: lib/qrstorage/services/qr_code_service.ex:97
-#: lib/qrstorage/services/qr_code_service.ex:101
+#: lib/qrstorage/services/qr_code_service.ex:102
+#: lib/qrstorage/services/qr_code_service.ex:106
 #, elixir-autogen, elixir-format
 msgid "Qr code tts not stored"
 msgstr ""
@@ -280,3 +280,8 @@ msgstr "Aufnahmen werden nach 30 Tagen Inaktivität gelöscht."
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text was automatically translated by DeepL."
 msgstr "Der Text wurde automatisch übersetzt von DeepL."
+
+#: lib/qrstorage/services/qr_code_service.ex:55
+#, elixir-autogen, elixir-format
+msgid "Rate limit reached."
+msgstr "Derzeit können keine QR-Codes erstellt werden. Bitte versuch es später erneut."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -227,8 +227,8 @@ msgstr ""
 msgid "Error while extracting audio file from plug: Invalid content type"
 msgstr ""
 
-#: lib/qrstorage/services/qr_code_service.ex:80
-#: lib/qrstorage/services/qr_code_service.ex:84
+#: lib/qrstorage/services/qr_code_service.ex:85
+#: lib/qrstorage/services/qr_code_service.ex:89
 #, elixir-autogen, elixir-format
 msgid "Qr code recording not extracted"
 msgstr ""
@@ -259,8 +259,8 @@ msgstr ""
 msgid "QR-Code has been deleted?"
 msgstr ""
 
-#: lib/qrstorage/services/qr_code_service.ex:97
-#: lib/qrstorage/services/qr_code_service.ex:101
+#: lib/qrstorage/services/qr_code_service.ex:102
+#: lib/qrstorage/services/qr_code_service.ex:106
 #, elixir-autogen, elixir-format
 msgid "Qr code tts not stored"
 msgstr ""
@@ -278,4 +278,9 @@ msgstr ""
 #: lib/qrstorage_web/templates/qr_code/partials/_translation_hint.html.heex:9
 #, elixir-autogen, elixir-format
 msgid "Text was automatically translated by DeepL."
+msgstr ""
+
+#: lib/qrstorage/services/qr_code_service.ex:55
+#, elixir-autogen, elixir-format
+msgid "Rate limit reached."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -228,8 +228,8 @@ msgstr ""
 msgid "Error while extracting audio file from plug: Invalid content type"
 msgstr ""
 
-#: lib/qrstorage/services/qr_code_service.ex:80
-#: lib/qrstorage/services/qr_code_service.ex:84
+#: lib/qrstorage/services/qr_code_service.ex:85
+#: lib/qrstorage/services/qr_code_service.ex:89
 #, elixir-autogen, elixir-format
 msgid "Qr code recording not extracted"
 msgstr ""
@@ -260,8 +260,8 @@ msgstr ""
 msgid "QR-Code has been deleted?"
 msgstr ""
 
-#: lib/qrstorage/services/qr_code_service.ex:97
-#: lib/qrstorage/services/qr_code_service.ex:101
+#: lib/qrstorage/services/qr_code_service.ex:102
+#: lib/qrstorage/services/qr_code_service.ex:106
 #, elixir-autogen, elixir-format
 msgid "Qr code tts not stored"
 msgstr ""
@@ -280,3 +280,8 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Text was automatically translated by DeepL."
 msgstr "Text was automatically translated by DeepL."
+
+#: lib/qrstorage/services/qr_code_service.ex:55
+#, elixir-autogen, elixir-format
+msgid "Rate limit reached."
+msgstr ""

--- a/test/qrstorage/services/rate_limiting_service_test.exs
+++ b/test/qrstorage/services/rate_limiting_service_test.exs
@@ -1,0 +1,72 @@
+defmodule Qrstorage.Services.RateLimitingServiceTest do
+  use Qrstorage.DataCase
+  use Qrstorage.StorageCase
+  use Qrstorage.RateLimitingCase
+
+  alias Qrstorage.QrCodes.QrCode
+  alias Qrstorage.Services.RateLimitingService
+
+  describe "allow?/1 without existing audio qr codes" do
+    test "allow?/1 returns false when the text is longer than the limit" do
+      qr_code = qr_code_with_text_length(5)
+
+      {result, logs} = with_log_and_rate_limit_set_to(1, fn -> RateLimitingService.allow?(qr_code) end)
+
+      assert result == false
+      assert logs =~ "Rate Limit reached"
+    end
+
+    test "allow?/1 returns true when the text is shorter than the limit" do
+      qr_code = qr_code_with_text_length(5)
+
+      {result, _logs} = with_log_and_rate_limit_set_to(15, fn -> RateLimitingService.allow?(qr_code) end)
+
+      assert result == true
+    end
+
+    test "allow?/1 returns true when the text is equal to the limit" do
+      qr_code = qr_code_with_text_length(5)
+
+      {result, _logs} = with_log_and_rate_limit_set_to(5, fn -> RateLimitingService.allow?(qr_code) end)
+
+      assert result == true
+    end
+  end
+
+  describe "allow?/1 with existing audio qr codes" do
+    setup do
+      audio_qr_code_fixture(%{text: "12345"})
+      :ok
+    end
+
+    test "allow?/1 returns false when the text is longer than the limit and the existing character count" do
+      qr_code = qr_code_with_text_length(2)
+
+      {result, logs} = with_log_and_rate_limit_set_to(6, fn -> RateLimitingService.allow?(qr_code) end)
+
+      assert result == false
+      assert logs =~ "Rate Limit reached"
+    end
+
+    test "allow?/1 returns true when the text is shorter than the limit and the existing character count" do
+      qr_code = qr_code_with_text_length(2)
+
+      {result, _logs} = with_log_and_rate_limit_set_to(8, fn -> RateLimitingService.allow?(qr_code) end)
+
+      assert result == true
+    end
+
+    test "allow?/1 returns true when the text is equal to the limit and the existing character count" do
+      qr_code = qr_code_with_text_length(2)
+
+      {result, _logs} = with_log_and_rate_limit_set_to(7, fn -> RateLimitingService.allow?(qr_code) end)
+
+      assert result == true
+    end
+  end
+
+  defp qr_code_with_text_length(length) do
+    text = String.duplicate("a", length)
+    %QrCode{text: text}
+  end
+end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -75,6 +75,13 @@ defmodule Qrstorage.DataCase do
         Repo.update!(Ecto.Changeset.cast(qr_code, %{last_accessed_at: last_access_date}, [:last_accessed_at]))
         qr_code
       end
+
+      def qr_code_with_insertion_date(attrs \\ %{}, insertion_date) do
+        attrs = Map.merge(@valid_attrs, attrs)
+        qr_code = qr_code_fixture(attrs)
+        Repo.update!(Ecto.Changeset.cast(qr_code, %{inserted_at: insertion_date}, [:inserted_at]))
+        qr_code
+      end
     end
   end
 

--- a/test/support/rate_limiting_case.ex
+++ b/test/support/rate_limiting_case.ex
@@ -1,0 +1,32 @@
+defmodule Qrstorage.RateLimitingCase do
+  @moduledoc """
+  This module defines the setup for tests requiring
+  access to the API for TTS.
+  """
+  use ExUnit.CaseTemplate
+  import ExUnit.CaptureLog
+
+  using do
+    quote do
+      import Qrstorage.RateLimitingCase
+    end
+  end
+
+  def with_log_and_rate_limit_set_to(limit, fun) do
+    with_log(fn ->
+      with_rate_limit_set_to(limit, fun)
+    end)
+  end
+
+  def with_rate_limit_set_to(limit, fun) do
+    previous_limit = Application.get_env(:qrstorage, :rate_limiting_character_limit)
+    Application.put_env(:qrstorage, :rate_limiting_character_limit, limit)
+
+    try do
+      fun.()
+    after
+      # set limit back:
+      Application.put_env(:qrstorage, :rate_limiting_character_limit, previous_limit)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a simple rate limiting mechanism. It stops accepting new qr codes when a configured rate limit has been reached within in the last 24 hours.

The limit can be configured with QR_CODE_RATE_LIMITING_CHARACTER_LIMIT and defaults to 25.000.

Close Issue: https://github.com/kitsteam/qrstorage/issues/314