### PR TITLE
chore: upgrade elixir (1.18), otp (27) and debian (bookworm)

### DIFF
--- a/.github/workflows/on_push_branch__execute_tests.yml
+++ b/.github/workflows/on_push_branch__execute_tests.yml
@@ -5,7 +5,7 @@ permissions:
 on: [push, pull_request]
 
 env:
-  CONTAINER_NAME: hexpm/elixir:1.18.3-erlang-27.3.4-debian-bookworm-20250428-slim
+  CONTAINER_NAME: hexpm/elixir:1.18.4-erlang-27.3.4.1-debian-bookworm-20250630-slim
 
 jobs:
   build_deps:
@@ -13,7 +13,7 @@ jobs:
     # Currently, this need to be synced manually with the Dockerfile. In the future, the workflow should be changed,
     # so that a development container is built from the Dockerfile, pushed, and then re-used in the following steps.
     # This would also remove the need to install cmake manually in each step:
-    container: hexpm/elixir:1.18.3-erlang-27.3.4-debian-bookworm-20250428-slim
+    container: hexpm/elixir:1.18.4-erlang-27.3.4.1-debian-bookworm-20250630-slim
 
     steps:
       # See https://github.com/actions/checkout
@@ -42,7 +42,7 @@ jobs:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
     # Docker Hub image that `container-job` executes in
-    container: hexpm/elixir:1.18.3-erlang-27.3.4-debian-bookworm-20250428-slim
+    container: hexpm/elixir:1.18.4-erlang-27.3.4.1-debian-bookworm-20250630-slim
 
     needs: build_deps
 
@@ -100,7 +100,7 @@ jobs:
 
   check_mix_format:
     runs-on: ubuntu-latest
-    container: hexpm/elixir:1.18.3-erlang-27.3.4-debian-bookworm-20250428-slim
+    container: hexpm/elixir:1.18.4-erlang-27.3.4.1-debian-bookworm-20250630-slim
 
     needs: build_deps
 
@@ -123,7 +123,7 @@ jobs:
 
   check_mix_sobelow:
     runs-on: ubuntu-latest
-    container: hexpm/elixir:1.18.3-erlang-27.3.4-debian-bookworm-20250428-slim
+    container: hexpm/elixir:1.18.4-erlang-27.3.4.1-debian-bookworm-20250630-slim
 
     needs: build_deps
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.13.3-erlang-24.3.4.2-debian-bullseye-20210902-slim
 # 
-ARG ELIXIR_VERSION=1.18.3
-ARG OTP_VERSION=27.3.4
-ARG DEBIAN_VERSION=bookworm-20250428-slim
+ARG ELIXIR_VERSION=1.18.4
+ARG OTP_VERSION=27.3.4.1
+ARG DEBIAN_VERSION=bookworm-20250630-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
Upgrades elixir, otp and debian:
```
ELIXIR_VERSION=1.18.4
OTP_VERSION=27.3.4.1
DEBIAN_VERSION=bookworm-20250630-slim
```